### PR TITLE
[Deps] Update Android Gradle Plugin to 8.1.0 alpha04

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,12 +37,10 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: 'temurin'
           cache: gradle
-      - name: Dependency Versions - Dependency Updates
-        run: ./gradlew dependencyUpdates
       - name: Build - Assemble (Debug)
         run: ./gradlew assembleDebug
       - name: Dependency Analysis - Build Health
-        run: ./gradlew assembleDebug
+        run: ./gradlew buildHealth
       - name: Static Analysis - Detekt without Type Resolution
         run: ./gradlew detekt
       - name: Static Analysis - Detekt with Type Resolution (Main)
@@ -56,7 +54,7 @@ jobs:
       - name: Test - Unit Test - Android Modules (Debug)
         run: ./gradlew testDebugUnitTest
       - name: Test - Unit Test - Code Coverage
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew jacoco
       - name: Test - Assemble UI Test - App Module (Debug)
         run: ./gradlew app:assembleDebugAndroidTest
   test:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,15 +52,15 @@ dependencies {
     androidTestImplementation(project(Projects.Implementation.Kotlin.UTILS))
     androidTestImplementation(project(Projects.TestImplementation.Kotlin.TEST))
 
+    androidTestImplementation(libs.androidx.recycler.view)
+    androidTestImplementation(libs.junit4)
     androidTestImplementation(libs.androidx.test.core.main)
     androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.test.espresso.contrib)
     androidTestImplementation(libs.okhttp.mock.web.server)
-    androidTestImplementation(libs.strikt)
 }
 
 dependencyAnalysis {
@@ -69,6 +69,11 @@ dependencyAnalysis {
             exclude(
                 libs.leak.canary.identifier(), // Ignore remove advise. Required for nav.
                 libs.androidx.navigation.fragment.ktx.identifier(), // Ignore remove advise. Required for nav.
+            )
+        }
+        onUsedTransitiveDependencies {
+            exclude(
+                libs.hamcrest.identifier(), // Ignore remove advise. Required for espresso.
             )
         }
     }

--- a/build-logic/convention/src/main/kotlin/io/petros/movies/Android.kt
+++ b/build-logic/convention/src/main/kotlin/io/petros/movies/Android.kt
@@ -319,6 +319,7 @@ object Android {
             "InvalidPackage",
             "DialogFragmentCallbacksDetector", // From Android Gradle Plugin version 7.4.0-alpha02 and onwards
             "UnknownIssueId", // From Android Gradle Plugin version 7.4.0-alpha02 and onwards
+            "GradleDependency",
         )
 
         val disabledDatabaseIssues = arrayOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.0.0-beta02"
+androidGradlePlugin = "8.1.0-alpha04"
 androidxAnnotation = "1.5.0"
 androidxAppCompat = "1.6.1"
 androidxArchCore = "2.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ glide = "4.14.2"
 gradleDoctor = "0.8.1"
 gson = "2.10.1"
 jacoco = "0.8.8"
+hamcrest = "2.2"
 junit4 = "4.13.2"
 koinAndroid = "3.3.3"
 koinCore = "3.3.3"
@@ -118,6 +119,7 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+hamcrest = { group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koinAndroid" }
 koin-core-main = { group = "io.insert-koin", name = "koin-core", version.ref = "koinCore" }


### PR DESCRIPTION
This PR includes:

1. [Update android gradle plugin to 8.1.0-alpha04 version](https://github.com/ParaskP7/sample-code-movies/pull/43/commits/32e687d79bb7c6290076681163f51a759471f82a)
2. [Suppress gradle dependency lint warning](https://github.com/ParaskP7/sample-code-movies/pull/43/commits/87985b3d313b1e1f5f5bf0b78f9c3ebdcce84d8b)
3. [Update github actions to fix some inconsistencies from copy-pasting](https://github.com/ParaskP7/sample-code-movies/pull/43/commits/0caa11132d17b4b59906e8ef4ada611cf2e4c104)
4. [Update various dependencies based on build health status](https://github.com/ParaskP7/sample-code-movies/pull/43/commits/7785c58f95fa4aec7424cd5f64bde3370903d050)